### PR TITLE
Add OCR anchors and Poppler-based OCR engine with caching

### DIFF
--- a/ocr/anchors.py
+++ b/ocr/anchors.py
@@ -1,0 +1,205 @@
+"""Utility definitions for locating anchors within OCR output.
+
+This module centralises all regular expressions and synonym mappings that
+are required to detect key Serbian financial statement terms in OCR text.
+
+The expressions are intentionally permissive – they accept minor spelling
+variations, casing differences and a mix of Cyrillic/Latin scripts.  The
+structures defined here are consumed by the OCR/indexing and extraction
+modules to match rows, headers and Matični broj identifiers reliably.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Dict, Iterable, List, Pattern
+
+# ---------------------------------------------------------------------------
+# Matični broj detection
+# ---------------------------------------------------------------------------
+
+
+MAT_BR_PATTERN: Pattern[str] = re.compile(
+    r"""
+    (?ix)                                   # ignore case, allow verbose mode
+    (?:ма[тт]ични|maticni|matični)          # word "Matični" with variants
+    \s*                                     # optional whitespace
+    (?:број|broj)                            # word "broj" in Cyrillic/Latin
+    \s*[:：\-\u2013]?\s*                   # optional delimiter
+    (?P<number>\d{8,9})                     # capture the numeric identifier
+    """
+)
+
+
+MB_INLINE_PATTERN: Pattern[str] = re.compile(r"(?<!\d)(\d{8,9})(?!\d)")
+
+
+MB_SYNONYMS: Dict[str, Iterable[str]] = {
+    "maticni_broj": [
+        "матични број",
+        "мат. број",
+        "матични бр",
+        "maticni broj",
+        "matični broj",
+        "mat. broj",
+        "MB",
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Form header detection
+# ---------------------------------------------------------------------------
+
+
+FORM_HEADER_PATTERNS: Dict[str, Pattern[str]] = {
+    "bu": re.compile(r"(?i)билан[сc]\s+успеха|bilans\s+uspeha"),
+    "bs": re.compile(r"(?i)билан[сc]\s+стања|bilans\s+stanja"),
+}
+
+
+FORM_HEADER_SYNONYMS: Dict[str, Iterable[str]] = {
+    "bu": [
+        "биланс успеха",
+        "биланс успjеха",
+        "биланc успеха",
+        "bilans uspeha",
+        "bilans uspjeha",
+        "bilans uspieha",
+        "bu",
+    ],
+    "bs": [
+        "биланс стања",
+        "биланс стања",
+        "биланc стања",
+        "bilans stanja",
+        "bilans stanje",
+        "bs",
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Row anchors (target metrics)
+# ---------------------------------------------------------------------------
+
+
+ROW_ANCHOR_PATTERNS: Dict[str, Pattern[str]] = {
+    "bu_revenue": re.compile(r"(?i)пословни\s+приходи"),
+    "bs_assets": re.compile(r"(?i)укупна\s+актива"),
+    "bs_loss": re.compile(r"(?i)губитак\s+изнад\s+висине\s+капитала"),
+}
+
+
+ROW_ANCHOR_SYNONYMS: Dict[str, Iterable[str]] = {
+    "bu_revenue": [
+        "пословни приходи",
+        "poslovni prihodi",
+        "приходи из пословања",
+    ],
+    "bs_assets": [
+        "укупна актива",
+        "ukupna aktiva",
+        "укупна актива (у 000 рсд)",
+    ],
+    "bs_loss": [
+        "губитак изнад висине капитала",
+        "gubitak iznad visine kapitala",
+        "губитак изнад висине капитала (у 000 рсд)",
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Year column headers
+# ---------------------------------------------------------------------------
+
+
+YEAR_COLUMN_PATTERNS: Dict[str, Pattern[str]] = {
+    "current": re.compile(r"(?i)текућ[ае]\s+годин[ае]"),
+    "previous": re.compile(r"(?i)претходн[ае]\s+годин[ае]"),
+}
+
+
+YEAR_COLUMN_SYNONYMS: Dict[str, Iterable[str]] = {
+    "current": [
+        "текућа година",
+        "текуће године",
+        "текућа г.",
+        "tekuca godina",
+        "tekuce godine",
+        "2023",  # placeholder for context-specific headers
+    ],
+    "previous": [
+        "претходна година",
+        "претходне године",
+        "претходна г.",
+        "prethodna godina",
+        "prethodne godine",
+        "2022",  # placeholder when tables use explicit year labels
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AnchorDefinition:
+    """Represents a canonical anchor with regex and synonym spellings."""
+
+    key: str
+    pattern: Pattern[str]
+    synonyms: List[str]
+
+    def matches(self, text: str) -> bool:
+        """Return ``True`` when the regex detects the anchor in ``text``."""
+
+        return bool(self.pattern.search(text))
+
+    def any_synonym_in(self, text: str) -> bool:
+        """Check whether any synonym is present inside the provided text."""
+
+        lowered = text.lower()
+        return any(syn.lower() in lowered for syn in self.synonyms)
+
+
+def build_anchor_map() -> Dict[str, AnchorDefinition]:
+    """Create a canonical anchor mapping for downstream modules."""
+
+    anchors: Dict[str, AnchorDefinition] = {}
+
+    for key, pattern in ROW_ANCHOR_PATTERNS.items():
+        anchors[key] = AnchorDefinition(
+            key=key,
+            pattern=pattern,
+            synonyms=list(ROW_ANCHOR_SYNONYMS.get(key, [])),
+        )
+
+    for key, pattern in YEAR_COLUMN_PATTERNS.items():
+        anchors[f"year_{key}"] = AnchorDefinition(
+            key=f"year_{key}",
+            pattern=pattern,
+            synonyms=list(YEAR_COLUMN_SYNONYMS.get(key, [])),
+        )
+
+    return anchors
+
+
+__all__ = [
+    "MAT_BR_PATTERN",
+    "MB_INLINE_PATTERN",
+    "MB_SYNONYMS",
+    "FORM_HEADER_PATTERNS",
+    "FORM_HEADER_SYNONYMS",
+    "ROW_ANCHOR_PATTERNS",
+    "ROW_ANCHOR_SYNONYMS",
+    "YEAR_COLUMN_PATTERNS",
+    "YEAR_COLUMN_SYNONYMS",
+    "AnchorDefinition",
+    "build_anchor_map",
+]
+

--- a/ocr/ocr_engine.py
+++ b/ocr/ocr_engine.py
@@ -1,0 +1,262 @@
+"""OCR engine implementation based on Poppler rendering and Tesseract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from pdf2image import convert_from_path, pdfinfo_from_path
+import pytesseract
+from pytesseract import Output, TesseractError
+
+
+DEFAULT_CACHE_PATH = Path("cache") / "cache.sqlite"
+DEFAULT_LOG_PATH = Path("logs") / "finstat_extractor.log"
+
+
+class OCRProcessingError(RuntimeError):
+    """Raised when OCR processing fails for a PDF document."""
+
+
+@dataclass
+class OcrPage:
+    page_number: int
+    text: str
+    tsv: List[Dict[str, str]]
+
+
+@dataclass
+class OcrResult:
+    pdf_path: str
+    pdf_hash: str
+    text: str
+    pages: List[OcrPage]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "pdf_path": self.pdf_path,
+            "pdf_hash": self.pdf_hash,
+            "text": self.text,
+            "pages": [asdict(page) for page in self.pages],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "OcrResult":
+        pages = [OcrPage(**page_dict) for page_dict in data.get("pages", [])]
+        return cls(
+            pdf_path=str(data.get("pdf_path", "")),
+            pdf_hash=str(data["pdf_hash"]),
+            text=str(data.get("text", "")),
+            pages=pages,
+        )
+
+
+class OCREngine:
+    """High level OCR engine that caches results in SQLite."""
+
+    def __init__(
+        self,
+        config: Dict[str, object],
+        cache_path: Path = DEFAULT_CACHE_PATH,
+        log_path: Path = DEFAULT_LOG_PATH,
+    ) -> None:
+        self.config = config
+        self.cache_path = Path(cache_path)
+        self.log_path = Path(log_path)
+
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.logger = self._configure_logger()
+
+        self._ensure_cache_schema()
+        self._configure_tesseract()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def process(self, pdf_path: Path) -> OcrResult:
+        """Perform OCR on the provided PDF file with caching."""
+
+        pdf_path = Path(pdf_path)
+        if not pdf_path.exists():
+            raise FileNotFoundError(pdf_path)
+
+        pdf_hash = self._compute_pdf_hash(pdf_path)
+        cached = self._load_from_cache(pdf_hash)
+        if cached is not None:
+            self.logger.info("Using cached OCR for %s", pdf_path)
+            return cached
+
+        try:
+            images = self._render_pdf(pdf_path)
+            result = self._run_tesseract(pdf_path, pdf_hash, images)
+        except Exception as exc:
+            self.logger.exception("Failed OCR for %s", pdf_path)
+            raise OCRProcessingError(str(exc)) from exc
+
+        self._store_in_cache(result)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _configure_logger(self) -> logging.Logger:
+        logger = logging.getLogger("finstat_extractor")
+        if not logger.handlers:
+            logger.setLevel(logging.INFO)
+            handler = logging.FileHandler(self.log_path, encoding="utf-8")
+            formatter = logging.Formatter(
+                "%(asctime)s [%(levelname)s] %(message)s", "%Y-%m-%d %H:%M:%S"
+            )
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+        logger.propagate = False
+        return logger
+
+    def _configure_tesseract(self) -> None:
+        tesseract_path = self.config.get("tesseract_path")
+        if tesseract_path:
+            pytesseract.pytesseract.tesseract_cmd = str(tesseract_path)
+
+    def _compute_pdf_hash(self, pdf_path: Path) -> str:
+        hasher = hashlib.sha1()
+        stat = pdf_path.stat()
+        hasher.update(str(stat.st_size).encode())
+        hasher.update(str(int(stat.st_mtime)).encode())
+        with pdf_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1_048_576), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+
+    def _render_pdf(self, pdf_path: Path) -> List["Image.Image"]:
+        dpi = int(self.config.get("dpi", 300))
+        page_limit = int(self.config.get("page_limit", 2))
+        poppler_dir = self.config.get("poppler_bin_dir")
+
+        info = pdfinfo_from_path(str(pdf_path), poppler_path=poppler_dir)
+        page_count = int(info.get("Pages", 0))
+        if page_count == 0:
+            self.logger.warning("PDF has zero pages: %s", pdf_path)
+            return []
+
+        last_page = min(page_limit, page_count) if page_limit else page_count
+
+        kwargs = {
+            "dpi": dpi,
+            "first_page": 1,
+            "poppler_path": poppler_dir,
+        }
+        if last_page:
+            kwargs["last_page"] = last_page
+
+        images = convert_from_path(str(pdf_path), **kwargs)
+        return images
+
+    def _run_tesseract(
+        self,
+        pdf_path: Path,
+        pdf_hash: str,
+        images: Iterable["Image.Image"],
+    ) -> OcrResult:
+        langs = self.config.get("ocr_langs", "srp+srp_latn")
+
+        page_results: List[OcrPage] = []
+        full_text_parts: List[str] = []
+
+        for page_number, image in enumerate(images, start=1):
+            try:
+                text = pytesseract.image_to_string(image, lang=langs)
+                tsv_string = pytesseract.image_to_data(
+                    image, lang=langs, output_type=Output.STRING
+                )
+            except TesseractError as exc:
+                self.logger.exception(
+                    "Tesseract failed on %s page %s", pdf_path, page_number
+                )
+                raise OCRProcessingError(str(exc)) from exc
+
+            page_results.append(
+                OcrPage(
+                    page_number=page_number,
+                    text=text,
+                    tsv=list(self._parse_tsv(tsv_string)),
+                )
+            )
+            full_text_parts.append(text)
+
+        result = OcrResult(
+            pdf_path=str(pdf_path),
+            pdf_hash=pdf_hash,
+            text="\n".join(full_text_parts),
+            pages=page_results,
+        )
+        return result
+
+    def _parse_tsv(self, tsv_string: str) -> Iterable[Dict[str, str]]:
+        lines = [line for line in tsv_string.splitlines() if line.strip()]
+        if not lines:
+            return []
+
+        header = lines[0].split("\t")
+        for row in lines[1:]:
+            values = row.split("\t")
+            if len(values) != len(header):
+                continue
+            yield {header[i]: values[i] for i in range(len(header))}
+
+    # ------------------------------------------------------------------
+    # Cache helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_cache_schema(self) -> None:
+        with sqlite3.connect(self.cache_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ocr_cache (
+                    pdf_hash TEXT PRIMARY KEY,
+                    pdf_path TEXT,
+                    payload TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    def _load_from_cache(self, pdf_hash: str) -> Optional[OcrResult]:
+        with sqlite3.connect(self.cache_path) as conn:
+            cursor = conn.execute(
+                "SELECT payload FROM ocr_cache WHERE pdf_hash = ?", (pdf_hash,)
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        payload = json.loads(row[0])
+        return OcrResult.from_dict(payload)
+
+    def _store_in_cache(self, result: OcrResult) -> None:
+        payload = json.dumps(result.to_dict())
+        with sqlite3.connect(self.cache_path) as conn:
+            conn.execute(
+                "REPLACE INTO ocr_cache(pdf_hash, pdf_path, payload, created_at)"
+                " VALUES (?, ?, ?, ?)",
+                (
+                    result.pdf_hash,
+                    result.pdf_path,
+                    payload,
+                    datetime.utcnow().isoformat(),
+                ),
+            )
+            conn.commit()
+
+
+__all__ = ["OCREngine", "OcrResult", "OcrPage", "OCRProcessingError"]
+


### PR DESCRIPTION
## Summary
- add comprehensive regular expressions and synonym dictionaries for detecting Matični broj, form headers, row anchors, and year columns
- implement a Poppler + Tesseract OCR engine with caching in SQLite and structured OCR results
- add structured logging of OCR operations to logs/finstat_extractor.log

## Testing
- python -m compileall ocr

------
https://chatgpt.com/codex/tasks/task_e_68d800e2c8f08326a4e5f57c39311a45