### PR TITLE
Handle legacy Excel format gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,6 +127,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     except DependencyError as exc:
         logger.error("%s", exc)
         return 2
+    except excel_io.UnsupportedExcelFormatError as exc:
+        logger.error("%s", exc)
+        return 2
     except FileNotFoundError as exc:
         logger.error("%s", exc)
         return 2


### PR DESCRIPTION
## Summary
- raise a descriptive error when `load_workbook` fails on legacy `.xls` files and expose the exception to callers
- surface the user-facing guidance in the CLI so users convert `.xls` workbooks to `.xlsx`
- add coverage ensuring the CLI logs the conversion hint instead of crashing on `.xls` input paths
- revert the README.md documentation update per review feedback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d84585557c83268eab155d3b403e7b