### PR TITLE
Allow CLI logger to receive OCR cache messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,7 +159,7 @@ def run(*, args: argparse.Namespace, config: Dict[str, object], logger: logging.
     stats = ProcessingStats(total_rows=len(rows))
     report_entries: List[ReportEntry] = []
 
-    engine = ocr_engine.OCREngine(config)
+    engine = ocr_engine.OCREngine(config, logger=logger)
     pdf_idx = pdf_index.build_index(
         period_preference=year_preference,
         ocr_provider=engine,

--- a/ocr/ocr_engine.py
+++ b/ocr/ocr_engine.py
@@ -65,6 +65,7 @@ class OCREngine:
         config: Dict[str, object],
         cache_path: Path = DEFAULT_CACHE_PATH,
         log_path: Path = DEFAULT_LOG_PATH,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         self.config = config
         self.cache_path = Path(cache_path)
@@ -73,7 +74,7 @@ class OCREngine:
         self.cache_path.parent.mkdir(parents=True, exist_ok=True)
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        self.logger = self._configure_logger()
+        self.logger = logger or self._configure_logger()
 
         self._ensure_cache_schema()
         self._configure_tesseract()

--- a/tests/test_ocr_engine.py
+++ b/tests/test_ocr_engine.py
@@ -1,0 +1,46 @@
+"""Tests for the OCR engine integration points."""
+
+from __future__ import annotations
+
+import logging
+import types
+
+from ocr.ocr_engine import OCREngine, OcrResult
+
+
+def test_process_logs_cached_message(monkeypatch, tmp_path, caplog):
+    pdf_path = tmp_path / "document.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    logger = logging.getLogger("test-ocr-engine")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+
+    engine = OCREngine(
+        {},
+        cache_path=tmp_path / "cache.sqlite",
+        log_path=tmp_path / "ocr.log",
+        logger=logger,
+    )
+
+    def fake_render(self, _pdf_path):  # pragma: no cover - helper for test only
+        return []
+
+    def fake_run(self, pdf_path, pdf_hash, images):  # pragma: no cover - helper for test only
+        return OcrResult(pdf_path=str(pdf_path), pdf_hash=pdf_hash, text="", pages=[])
+
+    monkeypatch.setattr(
+        engine, "_render_pdf", types.MethodType(fake_render, engine)
+    )
+    monkeypatch.setattr(
+        engine, "_run_tesseract", types.MethodType(fake_run, engine)
+    )
+
+    caplog.set_level(logging.INFO, logger=logger.name)
+
+    engine.process(pdf_path)
+    caplog.clear()
+
+    engine.process(pdf_path)
+
+    assert any("Using cached OCR" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- add optional logger injection support to the OCR engine so external callers can share logging configuration
- pass the CLI logger into the OCR engine instantiation to surface cache reuse messages during debug runs
- cover the cache logging behaviour with a unit test that verifies the reuse message is emitted

## Testing
- pytest tests/test_ocr_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d851d23ca483268fab34d7aac00f1b