### PR TITLE
Prevent selecting AOP codes as numeric values

### DIFF
--- a/tests/test_table_extractor.py
+++ b/tests/test_table_extractor.py
@@ -250,6 +250,37 @@ def test_extract_field_skips_formula_like_cluster_when_numeric_available():
     assert result.column_label == "current"
 
 
+def test_extract_field_skips_aop_cluster_between_anchor_and_value():
+    rows: List[dict] = []
+    rows.append(
+        _word(text="АОП", left=260, top=80, line=1, word_num=1)
+    )
+    rows.append(
+        _word(text="Пословни", left=120, top=150, line=2, word_num=1)
+    )
+    rows.append(
+        _word(text="приходи", left=200, top=150, line=2, word_num=2)
+    )
+    rows.append(
+        _word(text="0001", left=260, top=150, line=2, word_num=3)
+    )
+    rows.append(
+        _word(text="456", left=360, top=150, line=2, word_num=4)
+    )
+
+    result = extract_field_from_ocr(
+        _result_from_rows(rows),
+        anchor_key="bu_revenue",
+        field_name="revenue",
+        year_preference="current",
+    )
+
+    assert result.success
+    assert result.value == 456
+    assert result.raw_text == "456"
+    assert result.column_label is None
+
+
 def test_extract_field_uses_value_from_overlapping_line_to_right():
     rows: List[dict] = []
     rows.append(


### PR DESCRIPTION
## Summary
- detect the AOP column boundaries while scanning OCR pages and keep track of them
- filter numeric clusters whose centers fall inside the detected AOP column before scoring candidates
- add a regression test that skips the AOP code cluster when choosing the numeric value

## Testing
- pytest tests/test_table_extractor.py

------
https://chatgpt.com/codex/tasks/task_e_68d8cc0b54fc8326aa1353f4e368ae38