### PR TITLE
Ensure numeric clustering respects column bounds

### DIFF
--- a/tests/test_table_extractor.py
+++ b/tests/test_table_extractor.py
@@ -281,6 +281,47 @@ def test_extract_field_skips_aop_cluster_between_anchor_and_value():
     assert result.column_label is None
 
 
+def test_extract_field_respects_selected_column_boundary():
+    rows: List[dict] = []
+    rows.append(
+        _word(text="Текућа", left=300, top=60, line=1, word_num=1)
+    )
+    rows.append(
+        _word(text="година", left=380, top=60, line=1, word_num=2)
+    )
+    rows.append(
+        _word(text="Претходна", left=520, top=60, line=1, word_num=3)
+    )
+    rows.append(
+        _word(text="година", left=640, top=60, line=1, word_num=4)
+    )
+
+    rows.append(
+        _word(text="Пословни", left=120, top=160, line=2, word_num=1)
+    )
+    rows.append(
+        _word(text="приходи", left=220, top=160, line=2, word_num=2)
+    )
+    rows.append(
+        _word(text="123", left=360, top=160, line=2, word_num=3)
+    )
+    rows.append(
+        _word(text="456", left=560, top=160, line=2, word_num=4)
+    )
+
+    result = extract_field_from_ocr(
+        _result_from_rows(rows),
+        anchor_key="bu_revenue",
+        field_name="revenue",
+        year_preference="current",
+    )
+
+    assert result.success
+    assert result.value == 123
+    assert result.column_label == "current"
+    assert result.raw_text == "123"
+
+
 def test_extract_field_uses_value_from_overlapping_line_to_right():
     rows: List[dict] = []
     rows.append(


### PR DESCRIPTION
## Summary
- constrain numeric clustering to words whose centres fall in the detected year column window and extend bounds when columns are missing
- reuse column-aware bounds to re-split clusters and fall back to broader candidates when no column matches are found
- add a regression test that keeps adjacent current and previous year values separate

## Testing
- pytest tests/test_table_extractor.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d2120380832688fb58ae5e59f5a7