### PR TITLE
Limit OCR processing to 30 pages per PDF

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,5 +3,5 @@ poppler_bin_dir: "C:\\Users\\jn432pw\\Documents\\my_automation\\utils\\poppler-2
 ocr_langs: "srp+srp_latn"
 dpi: 300
 year_preference: "current"
-page_limit: 2
+page_limit: 30
 overwrite_nonempty: false

--- a/tests/test_ocr_engine.py
+++ b/tests/test_ocr_engine.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import logging
 import types
 
-from ocr.ocr_engine import OCREngine, OcrResult
+from ocr.ocr_engine import DEFAULT_PAGE_LIMIT, OCREngine, OcrResult
+
+
+def _make_dummy_pdf(tmp_path):
+    pdf_path = tmp_path / "dummy.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+    return pdf_path
 
 
 def test_process_logs_cached_message(monkeypatch, tmp_path, caplog):
@@ -44,3 +50,74 @@ def test_process_logs_cached_message(monkeypatch, tmp_path, caplog):
     engine.process(pdf_path)
 
     assert any("Using cached OCR" in message for message in caplog.messages)
+
+
+def test_render_pdf_applies_default_limit(monkeypatch, tmp_path):
+    pdf_path = _make_dummy_pdf(tmp_path)
+
+    logger = logging.getLogger("test-default-limit")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+
+    engine = OCREngine(
+        {},
+        cache_path=tmp_path / "cache.sqlite",
+        log_path=tmp_path / "ocr.log",
+        logger=logger,
+    )
+
+    monkeypatch.setattr(
+        "ocr.ocr_engine.pdfinfo_from_path",
+        lambda *args, **kwargs: {"Pages": DEFAULT_PAGE_LIMIT + 10},
+    )
+
+    captured_kwargs = {}
+
+    def fake_convert(_path, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr("ocr.ocr_engine.convert_from_path", fake_convert)
+
+    engine._render_pdf(pdf_path)
+
+    assert captured_kwargs.get("last_page") == DEFAULT_PAGE_LIMIT
+
+
+def test_render_pdf_logs_message_when_truncated(monkeypatch, tmp_path, caplog):
+    pdf_path = _make_dummy_pdf(tmp_path)
+
+    logger = logging.getLogger("test-truncated-limit")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+
+    engine = OCREngine(
+        {},
+        cache_path=tmp_path / "cache.sqlite",
+        log_path=tmp_path / "ocr.log",
+        logger=logger,
+    )
+
+    monkeypatch.setattr(
+        "ocr.ocr_engine.pdfinfo_from_path",
+        lambda *args, **kwargs: {"Pages": DEFAULT_PAGE_LIMIT + 5},
+    )
+
+    captured_kwargs = {}
+
+    def fake_convert(_path, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr("ocr.ocr_engine.convert_from_path", fake_convert)
+
+    caplog.set_level(logging.WARNING, logger=logger.name)
+
+    engine._render_pdf(pdf_path)
+
+    assert captured_kwargs.get("last_page") == DEFAULT_PAGE_LIMIT
+    assert any(
+        "processed only the first" in message.lower()
+        and str(DEFAULT_PAGE_LIMIT) in message
+        for message in caplog.messages
+    )


### PR DESCRIPTION
## Summary
- set the default OCR page limit to 30 pages and fall back to it when the configuration is missing or invalid
- warn users when a PDF exceeds the limit so they know only the first 30 pages were processed
- refresh the regression tests to cover the default limit and truncation message

## Testing
- pytest tests/test_ocr_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d56ee710832693e0c3bcc69ead04