### PR TITLE
Handle empty numeric strings as zero

### DIFF
--- a/extract/numeric.py
+++ b/extract/numeric.py
@@ -85,12 +85,12 @@ def normalize_numeric_string(
     if raw is None:
         raise NumericParseError("No value supplied")
 
-    text = str(raw).strip()
-    if not text:
-        raise NumericParseError("Empty string")
-
+    text = str(raw)
     text = text.replace("\u00a0", " ")
     text = text.replace("\u2013", "-").replace("\u2014", "-")
+    text = text.strip()
+    if not text:
+        return NumericParseResult(value=0, normalized_text="0")
 
     text, was_parenthesised = _strip_parentheses(text)
     text, sign = _normalise_sign(text)

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -26,7 +26,7 @@ def test_normalize_numeric_string_understands_parentheses_as_negative():
     assert result.normalized_text == "-12345"
 
 
-@pytest.mark.parametrize("raw", ["abc", "", None])
+@pytest.mark.parametrize("raw", ["abc", None])
 def test_normalize_numeric_string_rejects_invalid_inputs(raw):
     with pytest.raises(NumericParseError):
         normalize_numeric_string(raw)  # type: ignore[arg-type]
@@ -41,3 +41,10 @@ def test_normalize_numeric_string_respects_bounds_and_sign():
 
     with pytest.raises(NumericParseError):
         normalize_numeric_string("11", max_value=10)
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\u00a0", "\u00a0  "])
+def test_normalize_numeric_string_treats_empty_input_as_zero(raw):
+    result = normalize_numeric_string(raw)
+    assert result.value == 0
+    assert result.normalized_text == "0"


### PR DESCRIPTION
## Summary
- treat empty or whitespace numeric inputs as numeric zero during normalization
- verify app integration writes an extracted zero without errors
- extend numeric parsing tests to cover empty input scenarios

## Testing
- pytest tests/test_numeric.py tests/test_app_extraction.py

------
https://chatgpt.com/codex/tasks/task_e_68d924c9dbcc8326a9c3abf2933b166b