### PR TITLE
Use capital AOP 0401 anchor for loss extraction

### DIFF
--- a/extract/bs.py
+++ b/extract/bs.py
@@ -1,4 +1,4 @@
-"""Extractor helpers for "Биланс стања" documents."""
+"""Helpers dedicated to extracting values from the balance sheet (BS)."""
 
 from __future__ import annotations
 
@@ -6,8 +6,15 @@ from typing import Optional
 
 from ocr.ocr_engine import OcrResult
 
-from .models import ExtractionResult
-from .table_extractor import extract_field_from_ocr
+from .models import ExtractionMessage, ExtractionResult
+from .table_extractor import (
+    extract_capital_aop0401,
+    extract_field_from_ocr,
+)
+
+
+_LOSS_FIELD_NAME = "Губитак изнад висине капитала"
+_CAPITAL_AOP_CODE = "0401"
 
 
 def extract_ukupna_aktiva(
@@ -36,16 +43,105 @@ def extract_gubitak_iznad_visine_kapitala(
     min_value: Optional[int] = None,
     max_value: Optional[int] = None,
 ) -> ExtractionResult:
-    """Extract the "Губитак изнад висине капитала" metric from a BS OCR result."""
+    """Return the loss above capital, prioritising the capital formula."""
 
-    return extract_field_from_ocr(
+    capital_result = extract_capital_aop0401(
         ocr_result,
-        anchor_key="bs_loss",
-        field_name="Губитак изнад висине капитала",
         year_preference=year_preference,
         min_value=min_value,
         max_value=max_value,
     )
+
+    if capital_result.success and capital_result.value is not None:
+        computed_value = abs(capital_result.value) if capital_result.value < 0 else 0
+        loss_result = _clone_result_with_new_field(capital_result, _LOSS_FIELD_NAME)
+        loss_result.value = computed_value
+        loss_result.warnings.extend(capital_result.warnings)
+        loss_result.warnings.append(
+            ExtractionMessage(
+                code="diagnostic_value_source",
+                message=(
+                    "Value derived from capital AOP 0401 using the prescribed formula"
+                ),
+                context={
+                    "source": "capital_formula",
+                    "aop_code": _CAPITAL_AOP_CODE,
+                    "capital_value": capital_result.value,
+                    "computed_value": computed_value,
+                },
+            )
+        )
+        return loss_result
+
+    fallback_result = extract_field_from_ocr(
+        ocr_result,
+        anchor_key="bs_loss",
+        field_name=_LOSS_FIELD_NAME,
+        year_preference=year_preference,
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+    if fallback_result.success and fallback_result.value is not None:
+        if capital_result.errors:
+            fallback_result.warnings.append(
+                ExtractionMessage(
+                    code="capital_extraction_failed",
+                    message="Capital based derivation failed; using direct loss row",
+                    context={
+                        "attempted_source": "capital_formula",
+                        "aop_code": _CAPITAL_AOP_CODE,
+                        "errors": [msg.code for msg in capital_result.errors],
+                    },
+                )
+            )
+        fallback_result.warnings.extend(capital_result.warnings)
+        fallback_result.warnings.append(
+            ExtractionMessage(
+                code="diagnostic_value_source",
+                message="Value read directly from the loss row (AOP 0401)",
+                context={
+                    "source": "direct_row",
+                    "aop_code": _CAPITAL_AOP_CODE,
+                    "computed_value": fallback_result.value,
+                },
+            )
+        )
+        return fallback_result
+
+    return _combine_failed_results(capital_result, fallback_result)
+
+
+def _clone_result_with_new_field(
+    source: ExtractionResult, field_name: str
+) -> ExtractionResult:
+    clone = ExtractionResult(field_name=field_name)
+    clone.raw_text = source.raw_text
+    clone.normalized_text = source.normalized_text
+    clone.page_number = source.page_number
+    clone.anchor_text = source.anchor_text
+    clone.anchor_bbox = source.anchor_bbox
+    clone.column_label = source.column_label
+    clone.column_bbox = source.column_bbox
+    return clone
+
+
+def _combine_failed_results(
+    capital_result: ExtractionResult, fallback_result: ExtractionResult
+) -> ExtractionResult:
+    combined = ExtractionResult(field_name=_LOSS_FIELD_NAME)
+    combined.errors.extend(capital_result.errors)
+    combined.errors.extend(fallback_result.errors)
+    combined.warnings.extend(capital_result.warnings)
+    combined.warnings.extend(fallback_result.warnings)
+    if not combined.errors:
+        combined.add_error(
+            "value_not_found",
+            "Neither the capital formula nor the direct loss row produced a value",
+            source_attempts=["capital_formula", "direct_row"],
+            aop_code=_CAPITAL_AOP_CODE,
+        )
+    return combined
 
 
 __all__ = [

--- a/extract/table_extractor.py
+++ b/extract/table_extractor.py
@@ -315,6 +315,25 @@ def extract_field_from_ocr(
     return result
 
 
+def extract_capital_aop0401(
+    ocr_result: OcrResult,
+    *,
+    year_preference: Optional[str] = "current",
+    min_value: Optional[int] = None,
+    max_value: Optional[int] = None,
+) -> ExtractionResult:
+    """Extract the capital value from the AOP 0401 row."""
+
+    return extract_field_from_ocr(
+        ocr_result,
+        anchor_key="bs_capital_aop0401",
+        field_name="A. Капитал (AOP 0401)",
+        year_preference=year_preference,
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+
 def _build_lines(page: OcrPage) -> Iterable[OcrLine]:
     buckets: Dict[Tuple[int, int, int], List[OcrWord]] = {}
     for row in page.tsv:
@@ -1004,4 +1023,4 @@ def _cluster_in_aop_zone(
     return (aop_column.left - margin) <= center <= (aop_column.right + margin)
 
 
-__all__ = ["extract_field_from_ocr"]
+__all__ = ["extract_field_from_ocr", "extract_capital_aop0401"]

--- a/ocr/anchors.py
+++ b/ocr/anchors.py
@@ -90,6 +90,16 @@ ROW_ANCHOR_PATTERNS: Dict[str, Pattern[str]] = {
     "bu_revenue": re.compile(r"(?i)пословни\s+приходи"),
     "bs_assets": re.compile(r"(?i)укупна\s+актива"),
     "bs_loss": re.compile(r"(?i)губитак\s+изнад\s+висине\s+капитала"),
+    "bs_capital_aop0401": re.compile(
+        r"""
+        (?:
+            \bA\s*\.\s*капитал\b.*?0*401 |   # "A. КАПИТАЛ" row referencing AOP
+            \bAOP\s*0*401\b |                 # Latin AOP notation
+            \bАОП\s*0*401\b                   # Cyrillic AOP notation
+        )
+        """,
+        re.IGNORECASE | re.VERBOSE,
+    ),
 }
 
 
@@ -108,6 +118,23 @@ ROW_ANCHOR_SYNONYMS: Dict[str, Iterable[str]] = {
         "губитак изнад висине капитала",
         "gubitak iznad visine kapitala",
         "губитак изнад висине капитала (у 000 рсд)",
+    ],
+    "bs_capital_aop0401": [
+        "a. капитал",
+        "а. капитал",
+        "a капитал",
+        "a. kapital",
+        "a kapital",
+        "а капитал",
+        "капитал (аоп 0401)",
+        "капитал аоп 0401",
+        "капитал aop 0401",
+        "capital aop 0401",
+        "kapital aop 0401",
+        "aop 0401",
+        "аоп 0401",
+        "aop0401",
+        "a. capital",
     ],
 }
 

--- a/tests/test_bs.py
+++ b/tests/test_bs.py
@@ -1,0 +1,98 @@
+"""Tests covering balance sheet extraction helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from extract.bs import extract_gubitak_iznad_visine_kapitala
+from ocr.ocr_engine import OcrPage, OcrResult
+
+
+def _word(
+    *,
+    text: str,
+    left: int,
+    top: int,
+    width: int = 60,
+    height: int = 20,
+    page: int = 1,
+    block: int = 1,
+    par: int = 1,
+    line: int = 1,
+    word_num: int,
+) -> dict:
+    return {
+        "level": "5",
+        "page_num": str(page),
+        "block_num": str(block),
+        "par_num": str(par),
+        "line_num": str(line),
+        "word_num": str(word_num),
+        "left": str(left),
+        "top": str(top),
+        "width": str(width),
+        "height": str(height),
+        "conf": "95",
+        "text": text,
+    }
+
+
+def _result_from_rows(rows: Iterable[dict]) -> OcrResult:
+    row_list = list(rows)
+    page = OcrPage(
+        page_number=1,
+        text="\n".join(row["text"] for row in row_list),
+        tsv=row_list,
+    )
+    return OcrResult(pdf_path="dummy.pdf", pdf_hash="hash", text=page.text, pages=[page])
+
+
+def _capital_rows(value: str) -> List[dict]:
+    return [
+        _word(text="Текућа", left=520, top=40, line=1, word_num=1),
+        _word(text="година", left=600, top=40, line=1, word_num=2),
+        _word(text="A.", left=120, top=140, line=2, word_num=1),
+        _word(text="КАПИТАЛ", left=180, top=140, line=2, word_num=2),
+        _word(text="AOP", left=280, top=140, line=2, word_num=3),
+        _word(text="0401", left=360, top=140, line=2, word_num=4),
+        _word(text=value, left=520, top=140, line=2, word_num=5),
+    ]
+
+
+def test_extract_gubitak_uses_negative_capital():
+    result = extract_gubitak_iznad_visine_kapitala(
+        _result_from_rows(_capital_rows("-123")),
+        year_preference="current",
+    )
+
+    assert result.success
+    assert result.value == 123
+    diagnostic = next(
+        message
+        for message in result.warnings
+        if message.code == "diagnostic_value_source"
+    )
+    assert diagnostic.context["source"] == "capital_formula"
+    assert diagnostic.context["aop_code"] == "0401"
+    assert diagnostic.context["capital_value"] == -123
+    assert diagnostic.context["computed_value"] == 123
+
+
+def test_extract_gubitak_returns_zero_for_positive_capital():
+    result = extract_gubitak_iznad_visine_kapitala(
+        _result_from_rows(_capital_rows("456")),
+        year_preference="current",
+    )
+
+    assert result.success
+    assert result.value == 0
+    diagnostic = next(
+        message
+        for message in result.warnings
+        if message.code == "diagnostic_value_source"
+    )
+    assert diagnostic.context["source"] == "capital_formula"
+    assert diagnostic.context["aop_code"] == "0401"
+    assert diagnostic.context["capital_value"] == 456
+    assert diagnostic.context["computed_value"] == 0
+


### PR DESCRIPTION
## Summary
- add an OCR anchor and helper for the A. КАПИТАЛ / AOP 0401 row
- derive "Губитак изнад висине капитала" from capital with diagnostics and direct-row fallback
- cover positive and negative capital scenarios with new balance-sheet tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d928897a58832687a7006b6f7f4e2a