### PR TITLE
Add AOP-based anchor fallback for table extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ finstat_extractor/
   - BU: `(?i)пословни\s+приходи`
   - BS-1: `(?i)укупна\s+актива`
   - BS-2: `(?i)губитак\s+изнад\s+висине\s+капитала`
+- The extractor recognises uppercase, hyphenated and Latin variants of the row anchors (e.g. `POSLOVNI-PRIHODI`, `UKUPNA AKTIVA`, `КАПИТАЛ`) and has dedicated fallbacks for the AOP codes (`1001`, `0059`, `0401`). When a textual anchor is missing `_find_anchor_lines` will synthesise a combined row around the detected AOP code and tag it with `metadata["aop_fallback"] = True`; `_locate_numeric_cluster` must keep using the AOP column bounds in this mode so that split numeric tokens are preserved.
 - Year columns (headers; locate X ranges by bbox):
   - `(?i)текућ[ае]\s+годин[ае]` → prefer by default
   - `(?i)претходн[ае]\s+годин[ае]`

--- a/ocr/anchors.py
+++ b/ocr/anchors.py
@@ -87,9 +87,40 @@ FORM_HEADER_SYNONYMS: Dict[str, Iterable[str]] = {
 
 
 ROW_ANCHOR_PATTERNS: Dict[str, Pattern[str]] = {
-    "bu_revenue": re.compile(r"(?i)пословни\s+приходи"),
-    "bs_assets": re.compile(r"(?i)укупна\s+актива"),
-    "bs_loss": re.compile(r"(?i)губитак\s+изнад\s+висине\s+капитала"),
+    "bu_revenue": re.compile(
+        r"""
+        (?ix)
+        (?:пословни|poslovni)
+        [\s\-]*
+        (?:приходи|prihodi)
+        """,
+        re.VERBOSE,
+    ),
+    "bs_assets": re.compile(
+        r"""
+        (?ix)
+        (?:укупна|ukupna)
+        [\s\-]*
+        (?:актива|aktiva)
+        """,
+        re.VERBOSE,
+    ),
+    "bs_loss": re.compile(
+        r"""
+        (?ix)
+        (?:губитак|gubitak)
+        [\s\-]+
+        (?:изнад|iznad)
+        [\s\-]+
+        (?:висине|visine)
+        [\s\-]+
+        (?:капитала|kapitala|капитал|kapital)
+        """,
+        re.VERBOSE,
+    ),
+    "bu_revenue_aop": re.compile(r"\b0*1001\b"),
+    "bs_assets_aop": re.compile(r"\b0*0059\b"),
+    "bs_loss_aop": re.compile(r"\b0*0401\b"),
     "bs_capital_aop0401": re.compile(
         r"""
         (?:
@@ -108,16 +139,45 @@ ROW_ANCHOR_SYNONYMS: Dict[str, Iterable[str]] = {
         "пословни приходи",
         "poslovni prihodi",
         "приходи из пословања",
+        "ПОСЛОВНИ ПРИХОДИ",
+        "POSLOVNI PRIHODI",
+        "пословни-приходи",
+        "poslovni-prihodi",
     ],
     "bs_assets": [
         "укупна актива",
         "ukupna aktiva",
         "укупна актива (у 000 рсд)",
+        "UKUPNA AKTIVA",
+        "УКУПНА АКТИВА",
+        "ukupna-aktiva",
     ],
     "bs_loss": [
         "губитак изнад висине капитала",
         "gubitak iznad visine kapitala",
         "губитак изнад висине капитала (у 000 рсд)",
+        "ГУБИТАК ИЗНАД ВИСИНЕ КАПИТАЛА",
+        "gubitak-iznad-visine-kapitala",
+        "губитак изнад висине капитал",
+        "gubitak iznad visine kapital",
+    ],
+    "bu_revenue_aop": [
+        "1001",
+        "01001",
+        "aop 1001",
+        "аоп 1001",
+    ],
+    "bs_assets_aop": [
+        "0059",
+        "059",
+        "aop 0059",
+        "аоп 0059",
+    ],
+    "bs_loss_aop": [
+        "0401",
+        "401",
+        "aop 0401",
+        "аоп 0401",
     ],
     "bs_capital_aop0401": [
         "a. капитал",


### PR DESCRIPTION
## Summary
- expand row anchor patterns and synonyms to include uppercase/Latin variants and dedicated AOP code regexes
- enhance anchor detection to synthesise rows around AOP codes and mark fallback metadata for numeric lookup
- update numeric cluster selection to respect AOP column bounds and add unit tests and documentation for the new behaviour

## Testing
- pytest tests/test_table_extractor.py

------
https://chatgpt.com/codex/tasks/task_e_68d98a04b7ec8326a7d33787e34e6c98