### PR TITLE
Improve dependency checks for OCR requirements

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import importlib
 import inspect
 import logging
 import shutil
@@ -300,6 +301,19 @@ def configure_dependencies(config: Dict[str, object], *, logger: logging.Logger)
     config["poppler_bin_dir"] = resolve_poppler_path(config.get("poppler_bin_dir"))
     logger.debug("Tesseract binary: %s", config["tesseract_path"])
     logger.debug("Poppler bin directory: %s", config["poppler_bin_dir"])
+
+    for module_name, install_hint in (
+        ("cv2", "pip install opencv-python"),
+        ("pdfplumber", "pip install pdfplumber"),
+    ):
+        try:
+            importlib.import_module(module_name)
+        except ImportError as exc:
+            raise DependencyError(
+                f"Missing required dependency '{module_name}'. Install it via `{install_hint}`."
+            ) from exc
+        else:
+            logger.debug("Dependency '%s' is available", module_name)
 
 
 def resolve_tesseract_path(value: Optional[object]) -> str:

--- a/ocr/ocr_engine.py
+++ b/ocr/ocr_engine.py
@@ -320,7 +320,15 @@ class OCREngine:
 
     def _cv2(self):
         if self._cv2_module is None:
-            import cv2  # pylint: disable=import-outside-toplevel
+            try:
+                import cv2  # pylint: disable=import-outside-toplevel
+            except ImportError as exc:  # pragma: no cover - exercised via error handling tests
+                message = (
+                    "OpenCV (cv2) is required for image preprocessing. Install it via "
+                    "`pip install opencv-python`."
+                )
+                self.logger.error(message)
+                raise OCRProcessingError(message) from exc
 
             self._cv2_module = cv2
         return self._cv2_module

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,33 @@
+"""Tests for dependency validation helpers."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+import app
+
+
+def test_configure_dependencies_missing_cv2(monkeypatch):
+    """A friendly DependencyError is raised when cv2 cannot be imported."""
+
+    original_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "cv2":
+            raise ImportError("No module named 'cv2'")
+        return original_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(app, "resolve_tesseract_path", lambda value: "tesseract")
+    monkeypatch.setattr(app, "resolve_poppler_path", lambda value: "poppler")
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    config: dict[str, object] = {}
+    logger = logging.getLogger("dependency-test")
+
+    with pytest.raises(app.DependencyError) as excinfo:
+        app.configure_dependencies(config, logger=logger)
+
+    assert "pip install opencv-python" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- ensure app.configure_dependencies validates the availability of cv2 and pdfplumber with actionable error messages
- wrap the OpenCV import in the OCR engine so missing dependencies raise OCRProcessingError instead of raw tracebacks
- add a regression test covering the friendly dependency error when cv2 is unavailable

## Testing
- pytest tests/test_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68da4b43af888326a4ddaa81a44b1e66