### PR TITLE
Fix numeric cluster detection when AOP shares value line

### DIFF
--- a/extract/table_extractor.py
+++ b/extract/table_extractor.py
@@ -904,6 +904,7 @@ def _locate_numeric_cluster(
 
     relevant_words: List[OcrWord] = []
     all_relevant_words: List[OcrWord] = []
+    seen_word_ids: Set[int] = set()
 
     column_tolerance = 8
     column_left_bound: Optional[float] = None
@@ -940,6 +941,10 @@ def _locate_numeric_cluster(
     for word in anchor_line.words:
         if not word.text.strip():
             continue
+        word_id = id(word)
+        if word_id in seen_word_ids:
+            continue
+        seen_word_ids.add(word_id)
         all_relevant_words.append(word)
         if not _word_in_selected_column(word):
             continue
@@ -952,13 +957,15 @@ def _locate_numeric_cluster(
             continue
         if line.bottom < anchor_top or line.top > anchor_bottom:
             continue
-        if line.left < anchor_threshold:
-            continue
         for word in line.words:
             if not word.text.strip():
                 continue
             if word.right < anchor_threshold:
                 continue
+            word_id = id(word)
+            if word_id in seen_word_ids:
+                continue
+            seen_word_ids.add(word_id)
             all_relevant_words.append(word)
             if not _word_in_selected_column(word):
                 continue

--- a/tests/test_table_extractor.py
+++ b/tests/test_table_extractor.py
@@ -345,6 +345,33 @@ def test_extract_field_skips_split_letter_aop_column():
     assert not result.errors
 
 
+def test_extract_field_reads_value_when_aop_shares_value_line():
+    rows: List[dict] = []
+    rows.append(_word(text="Текућа", left=520, top=40, line=1, word_num=1))
+    rows.append(_word(text="година", left=600, top=40, line=1, word_num=2))
+
+    rows.append(_word(text="Губитак", left=160, top=150, line=2, word_num=1))
+    rows.append(_word(text="изнад", left=260, top=150, line=2, word_num=2))
+    rows.append(_word(text="висине", left=360, top=150, line=2, word_num=3))
+    rows.append(_word(text="капитала", left=460, top=150, line=2, word_num=4))
+
+    rows.append(_word(text="0401", left=80, top=150, line=3, word_num=1))
+    rows.append(_word(text="123", left=560, top=150, line=3, word_num=2))
+    rows.append(_word(text="456", left=640, top=150, line=3, word_num=3))
+
+    result = extract_field_from_ocr(
+        _result_from_rows(rows),
+        anchor_key="bs_loss",
+        field_name="loss",
+        year_preference="current",
+    )
+
+    assert result.success
+    assert result.value == 123456
+    assert result.column_label == "current"
+    assert not result.errors
+
+
 def test_extract_field_respects_selected_column_boundary():
     rows: List[dict] = []
     rows.append(


### PR DESCRIPTION
## Summary
- allow numeric cluster detection to consider lines that start left of the anchor while deduplicating shared OCR words
- add a regression test to ensure values are captured when an AOP token shares the value line

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db6c2687988326a73eb7f3d4447291